### PR TITLE
bump ydb-go-sdk version to 3.45.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/shopspring/decimal v1.2.0
 	github.com/stretchr/testify v1.8.1
 	github.com/syndtr/goleveldb v1.0.0
-	github.com/ydb-platform/ydb-go-sdk/v3 v3.44.0
+	github.com/ydb-platform/ydb-go-sdk/v3 v3.45.0
 	github.com/ziutek/mymysql v1.5.4
 	golang.org/x/net v0.7.0
 	google.golang.org/genproto v0.0.0-20230131230820-1c016267d619 // indirect

--- a/go.sum
+++ b/go.sum
@@ -868,6 +868,8 @@ github.com/ydb-platform/ydb-go-sdk/v3 v3.44.0-rc9 h1:Q4qcaIINJemibBCoVvIqRcgag/G
 github.com/ydb-platform/ydb-go-sdk/v3 v3.44.0-rc9/go.mod h1:oSLwnuilwIpaF5bJJMAofnGgzPJusoI3zWMNb8I+GnM=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.44.0 h1:QaJU87Qfh5Y3GB9NefavinTZQTePVPNSBYnjm6AV+wk=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.44.0/go.mod h1:oSLwnuilwIpaF5bJJMAofnGgzPJusoI3zWMNb8I+GnM=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.45.0 h1:mv/P4iWBMAp2MZnm0XjyfGFuF40fL+LSrZ5S50qDCKI=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.45.0/go.mod h1:oSLwnuilwIpaF5bJJMAofnGgzPJusoI3zWMNb8I+GnM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): bump ydb-go-sdk version to 3.45.0

## What is the current behavior?
Issue Number: 

## What is the new behavior?

## Other information

