### PR TITLE
Fix session insert interface slice commit panic(#2259) (#2260)

### DIFF
--- a/integrations/session_tx_test.go
+++ b/integrations/session_tx_test.go
@@ -185,3 +185,36 @@ func TestMultipleTransaction(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, 0, len(ms))
 }
+
+func TestInsertMulti2InterfaceTransaction(t *testing.T) {
+
+	type Multi2InterfaceTransaction struct {
+		ID         uint64 `xorm:"id pk autoincr"`
+		Name       string
+		Alias      string
+		CreateTime time.Time `xorm:"created"`
+		UpdateTime time.Time `xorm:"updated"`
+	}
+	assert.NoError(t, PrepareEngine())
+	assertSync(t, new(Multi2InterfaceTransaction))
+	session := testEngine.NewSession()
+	defer session.Close()
+	err := session.Begin()
+	assert.NoError(t, err)
+
+	users := []interface{}{
+		&Multi2InterfaceTransaction{Name: "a", Alias: "A"},
+		&Multi2InterfaceTransaction{Name: "b", Alias: "B"},
+		&Multi2InterfaceTransaction{Name: "c", Alias: "C"},
+		&Multi2InterfaceTransaction{Name: "d", Alias: "D"},
+	}
+	cnt, err := session.Insert(&users)
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, len(users), cnt)
+
+	assert.NotPanics(t, func() {
+		err = session.Commit()
+		assert.NoError(t, err)
+	})
+}

--- a/schemas/column.go
+++ b/schemas/column.go
@@ -89,6 +89,8 @@ func (col *Column) ValueOfV(dataStruct *reflect.Value) (*reflect.Value, error) {
 				v.Set(reflect.New(v.Type().Elem()))
 			}
 			v = v.Elem()
+		} else if v.Kind() == reflect.Interface {
+			v = reflect.Indirect(v.Elem())
 		}
 		v = v.FieldByIndex([]int{i})
 	}


### PR DESCRIPTION
[merge upstream PR]
Fix session insert interface slice commit panic(#2259) -- TestInsertMulti2InterfaceTransaction is the test case

Reviewed-on: https://gitea.com/xorm/xorm/pulls/2260